### PR TITLE
Add additional Boxing Day PH for NT

### DIFF
--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -50,9 +50,9 @@ module Holidays
             {:wday => 1, :week => 1, :name => "Recreation Day", :regions => [:au_tas_north]},
             {:wday => 2, :week => 1, :name => "Melbourne Cup Day", :regions => [:au_vic_melbourne, :au_vic]}],
       12 => [{:mday => 25, :observed => "to_tuesday_if_sunday_or_monday_if_saturday(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:au, :au_qld, :au_nsw, :au_act, :au_tas, :au_wa, :au_vic, :au_nt]},
-            {:mday => 26, :observed => "to_tuesday_if_sunday_or_monday_if_saturday(date)", :observed_arguments => [:date], :name => "Boxing Day", :regions => [:au_nsw, :au_vic, :au_qld, :au_act, :au_wa]},
-            {:mday => 26, :function => "additiona_boxing_day(date)", :function_arguments => [:date], :name => "Additional public holiday for Boxing Day", :regions => [:au_nsw, :au_vic, :au_qld, :au_act, :au_wa]},
-            {:function => "to_weekday_if_boxing_weekend_from_year(year)", :function_arguments => [:year], :name => "Boxing Day", :regions => [:au_tas, :au_nt]},
+            {:mday => 26, :observed => "to_tuesday_if_sunday_or_monday_if_saturday(date)", :observed_arguments => [:date], :name => "Boxing Day", :regions => [:au_nsw, :au_vic, :au_qld, :au_act, :au_wa, :au_nt]},
+            {:mday => 26, :function => "additiona_boxing_day(date)", :function_arguments => [:date], :name => "Additional public holiday for Boxing Day", :regions => [:au_nsw, :au_vic, :au_qld, :au_act, :au_wa, :au_nt]},
+            {:function => "to_weekday_if_boxing_weekend_from_year(year)", :function_arguments => [:year], :name => "Boxing Day", :regions => [:au_tas]},
             {:function => "to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday(year)", :function_arguments => [:year], :name => "Proclamation Day", :regions => [:au_sa]},
             {:mday => 25, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:au_sa]}]
       }


### PR DESCRIPTION
Discrepancy between FWO and NT Gov website in regard to Boxing Day 26/12 being regarded as public holiday.

On the NT Gov website both Boxing Day 26/12 and 28/12 are regarded as public holiday. I called up the NT Gov office and it has been confirmed that both days are considered public holidays and employees should get public holiday rates on both days worked. 

FWO are aware of the discrepancy and have advised me to follow NT Gov. They will still get back to me about the relevant changes. 

As such, 26/12 needs to be pushed as a public holiday.