### PR TITLE
PFC-4532 (fix) 2022 AFL VIC Grand Final PB 

### DIFF
--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -84,6 +84,8 @@ when 2020
   Date.civil(2020, 10, 23)
 when 2021
   Date.civil(2021, 9, 24)
+when 2022
+  Date.civil(2022, 9, 23)
 end
 },
 

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -120,6 +120,8 @@ assert_equal "ACT Reconciliation Day", (Holidays.on(Date.civil(2020, 6, 1), [:au
 
     assert_equal "Friday before the AFL Grand Final", (Holidays.on(Date.civil(2021, 9, 24), [:au_vic])[0] || {})[:name]
 
+    assert_equal "Friday before the AFL Grand Final", (Holidays.on(Date.civil(2022, 9, 23), [:au_vic])[0] || {})[:name]
+
     assert_equal "May Public Holiday", (Holidays.on(Date.civil(2005, 5, 16), [:au_sa])[0] || {})[:name]
 
     assert_equal "March Public Holiday", (Holidays.on(Date.civil(2014, 3, 10), [:au_sa])[0] || {})[:name]

--- a/test/defs/test_defs_north_america.rb
+++ b/test/defs/test_defs_north_america.rb
@@ -408,15 +408,16 @@ assert_equal "King Kamehameha I Day", (Holidays.on(Date.civil(2022, 6, 10), [:us
 
     assert_equal "King Kamehameha I Day", (Holidays.on(Date.civil(2017, 6, 11), [:us_hi])[0] || {})[:name]
 
-    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2017, 6, 19), [:us_tx])[0] || {})[:name]
+    assert_equal "Emancipation Day in Texas", (Holidays.on(Date.civil(2017, 6, 19), [:us_tx])[0] || {})[:name]
 
     assert_nil (Holidays.on(Date.civil(2017, 6, 20), [:us])[0] || {})[:name]
+assert_nil (Holidays.on(Date.civil(2020, 6, 19), [:us])[0] || {})[:name]
 assert_nil (Holidays.on(Date.civil(2021, 6, 21), [:us])[0] || {})[:name]
 
     assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2021, 6, 18), [:us], [:observed])[0] || {})[:name]
 
     assert_equal "West Virginia Day", (Holidays.on(Date.civil(2017, 6, 20), [:us_wv], [:observed])[0] || {})[:name]
-assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2020, 6, 19), [:us_wv], [:observed])[0] || {})[:name]
+assert_equal "West Virginia Day", (Holidays.on(Date.civil(2020, 6, 19), [:us_wv], [:observed])[0] || {})[:name]
 assert_equal "West Virginia Day", (Holidays.on(Date.civil(2021, 6, 21), [:us_wv], [:observed])[0] || {})[:name]
 
     assert_equal "West Virginia Day", (Holidays.on(Date.civil(2017, 6, 20), [:us_wv])[0] || {})[:name]

--- a/test/defs/test_defs_us.rb
+++ b/test/defs/test_defs_us.rb
@@ -193,15 +193,16 @@ assert_equal "King Kamehameha I Day", (Holidays.on(Date.civil(2022, 6, 10), [:us
 
     assert_equal "King Kamehameha I Day", (Holidays.on(Date.civil(2017, 6, 11), [:us_hi])[0] || {})[:name]
 
-    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2017, 6, 19), [:us_tx])[0] || {})[:name]
+    assert_equal "Emancipation Day in Texas", (Holidays.on(Date.civil(2017, 6, 19), [:us_tx])[0] || {})[:name]
 
     assert_nil (Holidays.on(Date.civil(2017, 6, 20), [:us])[0] || {})[:name]
+assert_nil (Holidays.on(Date.civil(2020, 6, 19), [:us])[0] || {})[:name]
 assert_nil (Holidays.on(Date.civil(2021, 6, 21), [:us])[0] || {})[:name]
 
     assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2021, 6, 18), [:us], [:observed])[0] || {})[:name]
 
     assert_equal "West Virginia Day", (Holidays.on(Date.civil(2017, 6, 20), [:us_wv], [:observed])[0] || {})[:name]
-assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2020, 6, 19), [:us_wv], [:observed])[0] || {})[:name]
+assert_equal "West Virginia Day", (Holidays.on(Date.civil(2020, 6, 19), [:us_wv], [:observed])[0] || {})[:name]
 assert_equal "West Virginia Day", (Holidays.on(Date.civil(2021, 6, 21), [:us_wv], [:observed])[0] || {})[:name]
 
     assert_equal "West Virginia Day", (Holidays.on(Date.civil(2017, 6, 20), [:us_wv])[0] || {})[:name]


### PR DESCRIPTION
Vic AFL Grand Final Public Holiday is hard coded. So I added 2022 with this PR.

I don't think Owen ran a `rake generate` for the last PR so mine includes tests for the US.