### PR TITLE
PFC-4905 (fix) Additional days for Norfolk Island

### DIFF
--- a/lib/generated_definitions/nf.rb
+++ b/lib/generated_definitions/nf.rb
@@ -15,15 +15,18 @@ module Holidays
               0 => [{:function => "easter(year)", :function_arguments => [:year], :function_modifier => -2, :name => "Good Friday", :regions => [:nf]},
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 1, :name => "Easter Monday", :regions => [:nf]}],
       1 => [{:mday => 1, :name => "New Year's Day", :regions => [:nf]},
+            {:mday => 1, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day New Year's Day)", :regions => [:nf]},
             {:mday => 26, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Australia Day", :regions => [:nf]}],
-      3 => [{:mday => 6, :name => "Foundation Day", :regions => [:nf]}],
+      3 => [{:mday => 6, :name => "Foundation Day", :regions => [:nf]},
+            {:mday => 6, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day Foundation Day)", :regions => [:nf]}],
       4 => [{:mday => 25, :name => "Anzac Day", :regions => [:nf]}],
       6 => [{:mday => 8, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Bounty Day", :regions => [:nf]},
             {:function => "monday_after_second_saturday(year)", :function_arguments => [:year], :name => "Queen's Birthday", :regions => [:nf]}],
       10 => [{:wday => 1, :week => 2, :name => "Norfolk Island Agricultural Show", :regions => [:nf]}],
-      11 => [{:wday => 3, :week => 4, :name => "Thanksgiving Day", :regions => [:nf]}],
+      11 => [{:wday => 3, :week => 5, :name => "Thanksgiving Day", :regions => [:nf]}],
       12 => [{:mday => 25, :name => "Christmas Day", :regions => [:nf]},
-            {:mday => 26, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Boxing Day", :regions => [:nf]}]
+            {:mday => 26, :name => "Boxing Day", :regions => [:nf]},
+            {:mday => 26, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day Boxing Day)", :regions => [:nf]}]
       }
     end
 

--- a/lib/generated_definitions/nf.rb
+++ b/lib/generated_definitions/nf.rb
@@ -46,7 +46,7 @@ elsif date.wday == 1
   date += 1
   date
 else
-  date
+  nil
 end
 },
 

--- a/lib/generated_definitions/nf.rb
+++ b/lib/generated_definitions/nf.rb
@@ -25,8 +25,8 @@ module Holidays
       10 => [{:wday => 1, :week => 2, :name => "Norfolk Island Agricultural Show", :regions => [:nf]}],
       11 => [{:wday => 3, :week => 5, :name => "Thanksgiving Day", :regions => [:nf]}],
       12 => [{:mday => 25, :name => "Christmas Day", :regions => [:nf]},
-            {:mday => 26, :name => "Boxing Day", :regions => [:nf]},
-            {:mday => 26, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day Boxing Day)", :regions => [:nf]}]
+            {:mday => 25, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day Christmas Day)", :regions => [:nf]},
+            {:mday => 26, :name => "Boxing Day", :regions => [:nf]}]
       }
     end
 

--- a/lib/generated_definitions/nf.rb
+++ b/lib/generated_definitions/nf.rb
@@ -25,9 +25,8 @@ module Holidays
       10 => [{:wday => 1, :week => 2, :name => "Norfolk Island Agricultural Show", :regions => [:nf]}],
       11 => [{:wday => 3, :week => 5, :name => "Thanksgiving Day", :regions => [:nf]}],
       12 => [{:mday => 25, :name => "Christmas Day", :regions => [:nf]},
-            {:mday => 25, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day Christmas Day)", :regions => [:nf]},
-            {:mday => 26, :name => "Boxing Day", :regions => [:nf]},
-            {:mday => 26, :function => "to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)", :function_arguments => [:date], :name => "(additional day Boxing Day)", :regions => [:nf]}]
+            {:mday => 25, :function => "to_tuesday_if_sunday_or_monday(date)", :function_arguments => [:date], :name => "(additional day Christmas Day)", :regions => [:nf]},
+            {:mday => 26, :name => "Boxing Day", :regions => [:nf]}]
       }
     end
 
@@ -38,7 +37,7 @@ second_sat_in_jun = Date.civil(year, 6, Holidays::Factory::DateCalculator.day_of
 second_sat_in_jun + 2
 },
 
-"to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)" => Proc.new { |date|
+"to_tuesday_if_sunday_or_monday(date)" => Proc.new { |date|
 if [6,0].include?(date.wday)
   date += 2
   date

--- a/lib/generated_definitions/nf.rb
+++ b/lib/generated_definitions/nf.rb
@@ -27,7 +27,7 @@ module Holidays
       12 => [{:mday => 25, :name => "Christmas Day", :regions => [:nf]},
             {:mday => 25, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day Christmas Day)", :regions => [:nf]},
             {:mday => 26, :name => "Boxing Day", :regions => [:nf]},
-            {:mday => 26, :observed => "to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday", :observed_arguments => , :name => "(additional day Boxing Day)", :regions => [:nf]}]
+            {:mday => 26, :function => "to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)", :function_arguments => [:date], :name => "(additional day Boxing Day)", :regions => [:nf]}]
       }
     end
 

--- a/lib/generated_definitions/nf.rb
+++ b/lib/generated_definitions/nf.rb
@@ -26,7 +26,8 @@ module Holidays
       11 => [{:wday => 3, :week => 5, :name => "Thanksgiving Day", :regions => [:nf]}],
       12 => [{:mday => 25, :name => "Christmas Day", :regions => [:nf]},
             {:mday => 25, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "(additional day Christmas Day)", :regions => [:nf]},
-            {:mday => 26, :name => "Boxing Day", :regions => [:nf]}]
+            {:mday => 26, :name => "Boxing Day", :regions => [:nf]},
+            {:mday => 26, :observed => "to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday", :observed_arguments => , :name => "(additional day Boxing Day)", :regions => [:nf]}]
       }
     end
 
@@ -35,6 +36,18 @@ module Holidays
         "monday_after_second_saturday(year)" => Proc.new { |year|
 second_sat_in_jun = Date.civil(year, 6, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, :saturday))
 second_sat_in_jun + 2
+},
+
+"to_monday_if_saturday_or_to_tuesday_if_sunday_or_monday(date)" => Proc.new { |date|
+if [6,0].include?(date.wday)
+  date += 2
+  date
+elsif date.wday == 1
+  date += 1
+  date
+else
+  date
+end
 },
 
 

--- a/lib/generated_definitions/nf.rb
+++ b/lib/generated_definitions/nf.rb
@@ -25,7 +25,7 @@ module Holidays
       10 => [{:wday => 1, :week => 2, :name => "Norfolk Island Agricultural Show", :regions => [:nf]}],
       11 => [{:wday => 3, :week => 5, :name => "Thanksgiving Day", :regions => [:nf]}],
       12 => [{:mday => 25, :name => "Christmas Day", :regions => [:nf]},
-            {:mday => 25, :function => "to_tuesday_if_sunday_or_monday(date)", :function_arguments => [:date], :name => "(additional day Christmas Day)", :regions => [:nf]},
+            {:mday => 25, :function => "to_tuesday_if_sunday(date)", :function_arguments => [:date], :name => "(additional day Christmas Day)", :regions => [:nf]},
             {:mday => 26, :name => "Boxing Day", :regions => [:nf]}]
       }
     end
@@ -37,12 +37,9 @@ second_sat_in_jun = Date.civil(year, 6, Holidays::Factory::DateCalculator.day_of
 second_sat_in_jun + 2
 },
 
-"to_tuesday_if_sunday_or_monday(date)" => Proc.new { |date|
+"to_tuesday_if_sunday(date)" => Proc.new { |date|
 if [6,0].include?(date.wday)
   date += 2
-  date
-elsif date.wday == 1
-  date += 1
   date
 else
   nil


### PR DESCRIPTION
## Description of changes

Link to [PFC-4905 here](https://tandadocs.atlassian.net/browse/PFC-4905).

This PR is to add public holidays to the the Norfolk Island list.

2022 dates:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/19569654/202183334-cfcdebf8-b8fd-4ce2-b2d5-b4f8b3ba6692.png">

2023 dates:

<img width="674" alt="image" src="https://user-images.githubusercontent.com/19569654/202183385-63784cf5-c14d-4053-b6b6-94ab3c611bd5.png">

## Notes for code reviewers

Each new day calls the `observed: to_monday_if_weekend(date)` meaning that if this public holiday falls on the weekend they'll get an extra day. Otherwise this method will give us nil so it will never double up if the public holiday is on a weekday.

Made a special function for the observed Christmas day to jump from sunday to tuesday. Only applies when Christmas falls on Sunday.

## Notes for testing

Will get all three repo's in sync so will test on the dev server in Payaus repo.