### PR TITLE
L2S-2153 - Remove 2nd of Jan from ES public holidays 2023

### DIFF
--- a/lib/generated_definitions/es.rb
+++ b/lib/generated_definitions/es.rb
@@ -15,7 +15,7 @@ module Holidays
               0 => [{:function => "easter(year)", :function_arguments => [:year], :function_modifier => -3, :name => "Jueves Santo", :regions => [:es_pv, :es_na, :es_an, :es_ib, :es_cm, :es_mu, :es_m, :es_ar, :es_cl, :es_cn, :es_lo, :es_ga, :es_ce, :es_o, :es_ex]},
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => -2, :name => "Viernes Santo", :regions => [:es]},
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 1, :name => "Lunes de Pascua", :regions => [:es_pv, :es_ct, :es_na, :es_v, :es_vc]}],
-      1 => [{:mday => 1, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Año Nuevo", :regions => [:es]},
+      1 => [{:mday => 1,  :year_ranges => [{:before => 2023}],:observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Año Nuevo", :regions => [:es]},
             {:mday => 6, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Día de Reyes", :regions => [:es]}],
       2 => [{:mday => 28, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Día de Andalucía", :regions => [:es_an]}],
       3 => [{:mday => 1, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Día de las Islas Baleares", :regions => [:es_ib]},

--- a/lib/generated_definitions/europe.rb
+++ b/lib/generated_definitions/europe.rb
@@ -157,7 +157,7 @@ module Holidays
             {:mday => 6, :name => "Heilige Drei Könige", :regions => [:de_bw, :de_by, :de_st]},
             {:mday => 1, :name => "Πρωτοχρονιά", :regions => [:el]},
             {:mday => 6, :name => "Θεοφάνεια", :regions => [:el]},
-            {:mday => 1, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Año Nuevo", :regions => [:es]},
+            {:mday => 1,  :year_ranges => [{:before => 2023}],:observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Año Nuevo", :regions => [:es]},
             {:mday => 6, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Día de Reyes", :regions => [:es]},
             {:mday => 1, :name => "Jour de l'an", :regions => [:fr]},
             {:mday => 1, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:gb]},


### PR DESCRIPTION
Spain recently changed their bank holidays as of 2023 so removing the 2nd of Jan.

https://tandadocs.atlassian.net/browse/L2S-2153