### PR TITLE
L2S-113 - Add Kings Coronation to GB BH 2023

### DIFF
--- a/lib/generated_definitions/europe.rb
+++ b/lib/generated_definitions/europe.rb
@@ -206,6 +206,7 @@ module Holidays
             {:mday => 1, :name => "Fête du travail", :regions => [:fr]},
             {:mday => 8, :name => "Victoire 1945", :regions => [:fr]},
             {:wday => 1, :week => 1, :name => "Early May Bank Holiday", :regions => [:gb]},
+            {:mday => 8,  :year_ranges => [{:limited => [2023]}],:name => "Bank holiday for the coronation of King Charles III", :regions => [:gb]},
             {:mday => 9, :name => "Liberation Day", :regions => [:je, :gb_jsy, :gg, :gb_gsy]},
             {:wday => 1, :week => -1,  :year_ranges => [{:before => 2021},{:after => 2023}],:name => "Spring Bank Holiday", :regions => [:gb]},
             {:mday => 1, :name => "Međunarodni praznik rada", :regions => [:hr]},

--- a/lib/generated_definitions/gb.rb
+++ b/lib/generated_definitions/gb.rb
@@ -19,6 +19,7 @@ module Holidays
       3 => [{:mday => 5, :name => "St. Piran's Day", :regions => [:gb_con]},
             {:mday => 17, :name => "St. Patrick's Day", :regions => [:gb_nir]}],
       5 => [{:wday => 1, :week => 1, :name => "Early May Bank Holiday", :regions => [:gb]},
+            {:mday => 8,  :year_ranges => [{:limited => [2023]}],:name => "Bank holiday for the coronation of King Charles III", :regions => [:gb]},
             {:mday => 9, :name => "Liberation Day", :regions => [:je, :gb_jsy, :gg, :gb_gsy]},
             {:wday => 1, :week => -1,  :year_ranges => [{:before => 2021},{:after => 2023}],:name => "Spring Bank Holiday", :regions => [:gb]}],
       6 => [{:mday => 2,  :year_ranges => [{:limited => [2022]}],:name => "Spring Bank Holiday", :regions => [:gb]},


### PR DESCRIPTION
https://tandadocs.atlassian.net/browse/L2S-113

Add Kings Coronation to the UK Bank holidays for 2023 only.