### PR TITLE
PFC-5174 (fix) Add Easter Sunday for NT 

### DIFF
--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -17,6 +17,7 @@ module Holidays
             {:function => "easter(year)", :function_arguments => [:year], :name => "Easter Sunday", :regions => [:au_nsw, :au_vic]},
             {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2017}],:name => "Easter Sunday", :regions => [:au_qld, :au_act]},
             {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2021}],:name => "Easter Sunday", :regions => [:au_wa]},
+            {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2022}],:name => "Easter Sunday", :regions => [:au_nt]},
             {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:limited => 2022}],:name => "Easter Sunday", :regions => [:au_nt]},
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 1, :name => "Easter Monday", :regions => [:au]},
             {:function => "afl_grand_final(year)", :function_arguments => [:year], :name => "Friday before the AFL Grand Final", :regions => [:au_vic]}],

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -230,5 +230,9 @@ assert_equal "ACT Reconciliation Day", (Holidays.on(Date.civil(2020, 6, 1), [:au
 
     assert_equal "Picnic Day", (Holidays.on(Date.civil(2021, 8, 2), [:"au-nt"])[0] || {})[:name]
 
+    assert_nil (Holidays.on(Date.civil(2022, 4, 17), [:"au-nt"])[0] || {})[:name]
+
+    assert_equal "Easter Sunday", (Holidays.on(Date.civil(2023, 4, 9), [:au_nt])[0] || {})[:name]
+
   end
 end


### PR DESCRIPTION
## Description of changes

Link to [PFC-5174 here](https://tandadocs.atlassian.net/browse/PFC-5174)

NT finally get Easter Sunday as a public holiday.

## Notes for code reviewers

Added tests and made it so this public holiday only applies from 2023 and into the future.

## Notes for designers

Nil

## Notes for testing

Run tests in the holidays repo. Shows up in prebuilt holidays, as expected.

![image](https://user-images.githubusercontent.com/19569654/224482010-ab9c6fd3-bf3e-4d63-ba72-bebbe8a4392b.png)

---

!no-server

[♻️ Recreate MS](https://tandadocs.atlassian.net/wiki/spaces/DEV/pages/1386905601/Recreate+a+Multi-Staging+Branch) | [🐞 Debugging MS](https://tandadocs.atlassian.net/wiki/spaces/DEV/pages/414089232/Debug+MS+issues+in+AWS) | [🦾 MS Commands](https://github.com/TandaHQ/payaus/tree/master/config/deploy/multi-staging#how-to-use-ms) | [⛹️ Skills Matrix](https://docs.google.com/spreadsheets/d/13dTaNgxvT1Bj7H-5-B-j8xU_9Y5EQE9nn6j4kYRep5A/edit#gid=0) | [💯 Code Review Guide](https://tandadocs.atlassian.net/wiki/spaces/DEV/pages/1102839829/Code+Reviewing+Tests) | [⚡️ Design Guide -- TBA!]()
