### PR TITLE
[Ruby 3] Set required ruby version to allow greater than or equal to 2.4

### DIFF
--- a/holidays.gemspec
+++ b/holidays.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^test/)
   gem.require_paths = ['lib']
   gem.licenses      = ['MIT']
-  gem.required_ruby_version = '~> 2.2'
+  gem.required_ruby_version = '>= 2.4'
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rake', '~> 12.0'
   gem.add_development_dependency 'simplecov', '~> 0.15'


### PR DESCRIPTION
Copied the changes from this commit for Ruby 3 support https://github.com/holidays/holidays/commit/a090002d2ce3f8bc29bca1b16a740db6dcb7fad7

Note: definitions submodule was for some reason pointing to a non-existing commit so I updated it to the latest commit here: https://github.com/TandaHQ/definitions/commit/16fc0002acf16cdf3bcf4b9f16031b497b5b8000