### PR TITLE
L2S-2864 (fix) Updated Definitions folder for AFL Grand Final PH Update

### DIFF
--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -92,6 +92,12 @@ when 2021
   Date.civil(2021, 9, 24)
 when 2022
   Date.civil(2022, 9, 23)
+when 2023
+  Date.civil(2023, 9, 29)
+when 2024
+  Date.civil(2024, 9, 27)
+when 2025
+  Date.civil(2025, 9, 26)
 end
 },
 

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -127,6 +127,12 @@ assert_equal "ACT Reconciliation Day", (Holidays.on(Date.civil(2020, 6, 1), [:au
 
     assert_equal "Friday before the AFL Grand Final", (Holidays.on(Date.civil(2022, 9, 23), [:au_vic])[0] || {})[:name]
 
+    assert_equal "Friday before the AFL Grand Final", (Holidays.on(Date.civil(2023, 9, 29), [:au_vic])[0] || {})[:name]
+
+    assert_equal "Friday before the AFL Grand Final", (Holidays.on(Date.civil(2024, 9, 27), [:au_vic])[0] || {})[:name]
+
+    assert_equal "Friday before the AFL Grand Final", (Holidays.on(Date.civil(2025, 9, 26), [:au_vic])[0] || {})[:name]
+
     assert_equal "May Public Holiday", (Holidays.on(Date.civil(2005, 5, 16), [:au_sa])[0] || {})[:name]
 
     assert_equal "March Public Holiday", (Holidays.on(Date.civil(2014, 3, 10), [:au_sa])[0] || {})[:name]


### PR DESCRIPTION
This PR is to do with [L2S-2864](https://tandadocs.atlassian.net/browse/L2S-2864)

The previous [PR](https://github.com/TandaHQ/definitions/pull/62) related to this involved updating the definitions repo.

This PR includes the updated definitions repo, along with the generated functions.

[L2S-2864]: https://tandadocs.atlassian.net/browse/L2S-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ