### PR TITLE
Hotfix: Executed rake generate after updating definitions

### DIFF
--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -16,6 +16,7 @@ module Holidays
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => -1, :name => "Easter Saturday", :regions => [:au_nsw, :au_vic, :au_qld, :au_nt, :au_act, :au_sa]},
             {:function => "easter(year)", :function_arguments => [:year], :name => "Easter Sunday", :regions => [:au_nsw, :au_vic]},
             {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2017}],:name => "Easter Sunday", :regions => [:au_qld, :au_act]},
+            {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2024}],:name => "Easter Sunday", :regions => [:au_sa]},
             {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2021}],:name => "Easter Sunday", :regions => [:au_wa]},
             {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2022}],:name => "Easter Sunday", :regions => [:au_nt]},
             {:function => "easter(year)", :function_arguments => [:year],  :year_ranges => [{:limited => 2022}],:name => "Easter Sunday", :regions => [:au_nt]},

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -239,6 +239,8 @@ assert_equal "ACT Reconciliation Day", (Holidays.on(Date.civil(2020, 6, 1), [:au
 
     assert_equal "Easter Sunday", (Holidays.on(Date.civil(2017, 4, 16), [:au_qld])[0] || {})[:name]
 
+    assert_equal "Easter Sunday", (Holidays.on(Date.civil(2024, 3, 31), [:au_sa])[0] || {})[:name]
+
     assert_equal "Easter Sunday", (Holidays.on(Date.civil(2022, 4, 17), [:au_wa])[0] || {})[:name]
 
     assert_equal "Picnic Day", (Holidays.on(Date.civil(2021, 8, 2), [:"au-nt"])[0] || {})[:name]


### PR DESCRIPTION
**Ticket:** https://tandadocs.atlassian.net/browse/L2S-3570

 - Executed Rake generate after updating the definitions file to automatically update the repo
