### PR TITLE
Bump definitions to pickup MLK comma change

### DIFF
--- a/lib/generated_definitions/federal_reserve.rb
+++ b/lib/generated_definitions/federal_reserve.rb
@@ -13,7 +13,7 @@ module Holidays
     def self.holidays_by_month
       {
               1 => [{:mday => 1, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:federal_reserve]},
-            {:wday => 1, :week => 3, :name => "Birthday of Martin Luther King, Jr", :regions => [:federal_reserve]}],
+            {:wday => 1, :week => 3, :name => "Birthday of Martin Luther King Jr", :regions => [:federal_reserve]}],
       2 => [{:wday => 1, :week => 3, :name => "Washington's Birthday", :regions => [:federal_reserve]}],
       5 => [{:wday => 1, :week => -1, :name => "Memorial Day", :regions => [:federal_reserve]}],
       7 => [{:mday => 4, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Independence Day", :regions => [:federal_reserve]}],

--- a/lib/generated_definitions/north_america.rb
+++ b/lib/generated_definitions/north_america.rb
@@ -28,7 +28,7 @@ module Holidays
             {:wday => 1, :week => 3, :name => "Martin Luther King's and Robert E. Lee's Birthdays", :regions => [:us_ms]},
             {:wday => 1, :week => 3, :name => "Idaho Human Rights Day", :regions => [:us_id]},
             {:wday => 1, :week => 3, :name => "Civil Rights Day", :regions => [:us_ar]},
-            {:wday => 1, :week => 3, :name => "Martin Luther King, Jr. Day", :regions => [:us]},
+            {:wday => 1, :week => 3, :name => "Martin Luther King Jr. Day", :regions => [:us]},
             {:function => "us_inauguration_day(year)", :function_arguments => [:year], :name => "Inauguration Day", :regions => [:us_tx, :us_dc, :us_la, :us_md, :us_va]},
             {:function => "lee_jackson_day(year, month)", :function_arguments => [:year, :month], :name => "Lee-Jackson Day", :regions => [:us_va]},
             {:mday => 19, :name => "Confederate Heroes Day", :regions => [:us_tx]}],

--- a/lib/generated_definitions/nyse.rb
+++ b/lib/generated_definitions/nyse.rb
@@ -14,7 +14,7 @@ module Holidays
       {
               0 => [{:function => "easter(year)", :function_arguments => [:year], :function_modifier => -2, :name => "Good Friday", :regions => [:nyse]}],
       1 => [{:mday => 1, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:nyse]},
-            {:wday => 1, :week => 3, :name => "Martin Luther King, Jr. Day", :regions => [:nyse]}],
+            {:wday => 1, :week => 3, :name => "Martin Luther King Jr. Day", :regions => [:nyse]}],
       2 => [{:wday => 1, :week => 3, :name => "Presidents' Day", :regions => [:nyse]}],
       5 => [{:wday => 1, :week => -1, :name => "Memorial Day", :regions => [:nyse]}],
       7 => [{:mday => 4, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Independence Day", :regions => [:nyse]}],

--- a/lib/generated_definitions/us.rb
+++ b/lib/generated_definitions/us.rb
@@ -21,7 +21,7 @@ module Holidays
             {:wday => 1, :week => 3, :name => "Martin Luther King's and Robert E. Lee's Birthdays", :regions => [:us_ms]},
             {:wday => 1, :week => 3, :name => "Idaho Human Rights Day", :regions => [:us_id]},
             {:wday => 1, :week => 3, :name => "Civil Rights Day", :regions => [:us_ar]},
-            {:wday => 1, :week => 3, :name => "Martin Luther King, Jr. Day", :regions => [:us]},
+            {:wday => 1, :week => 3, :name => "Martin Luther King Jr. Day", :regions => [:us]},
             {:function => "us_inauguration_day(year)", :function_arguments => [:year], :name => "Inauguration Day", :regions => [:us_tx, :us_dc, :us_la, :us_md, :us_va]},
             {:function => "lee_jackson_day(year, month)", :function_arguments => [:year, :month], :name => "Lee-Jackson Day", :regions => [:us_va]},
             {:mday => 19, :name => "Confederate Heroes Day", :regions => [:us_tx]}],

--- a/test/defs/test_defs_federal_reserve.rb
+++ b/test/defs/test_defs_federal_reserve.rb
@@ -9,7 +9,7 @@ class Federal_reserveDefinitionTests < Test::Unit::TestCase  # :nodoc:
   def test_federal_reserve
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2012, 1, 2), [:federal_reserve], [:observed])[0] || {})[:name]
 
-    assert_equal "Birthday of Martin Luther King, Jr", (Holidays.on(Date.civil(2012, 1, 16), [:federal_reserve], [:observed])[0] || {})[:name]
+    assert_equal "Birthday of Martin Luther King Jr", (Holidays.on(Date.civil(2012, 1, 16), [:federal_reserve], [:observed])[0] || {})[:name]
 
     assert_equal "Washington's Birthday", (Holidays.on(Date.civil(2012, 2, 20), [:federal_reserve], [:observed])[0] || {})[:name]
 
@@ -29,7 +29,7 @@ class Federal_reserveDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2013, 1, 1), [:federal_reserve], [:observed])[0] || {})[:name]
 
-    assert_equal "Birthday of Martin Luther King, Jr", (Holidays.on(Date.civil(2013, 1, 21), [:federal_reserve], [:observed])[0] || {})[:name]
+    assert_equal "Birthday of Martin Luther King Jr", (Holidays.on(Date.civil(2013, 1, 21), [:federal_reserve], [:observed])[0] || {})[:name]
 
     assert_equal "Washington's Birthday", (Holidays.on(Date.civil(2013, 2, 18), [:federal_reserve], [:observed])[0] || {})[:name]
 
@@ -49,7 +49,7 @@ class Federal_reserveDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2014, 1, 1), [:federal_reserve], [:observed])[0] || {})[:name]
 
-    assert_equal "Birthday of Martin Luther King, Jr", (Holidays.on(Date.civil(2014, 1, 20), [:federal_reserve], [:observed])[0] || {})[:name]
+    assert_equal "Birthday of Martin Luther King Jr", (Holidays.on(Date.civil(2014, 1, 20), [:federal_reserve], [:observed])[0] || {})[:name]
 
     assert_equal "Washington's Birthday", (Holidays.on(Date.civil(2014, 2, 17), [:federal_reserve], [:observed])[0] || {})[:name]
 
@@ -69,7 +69,7 @@ class Federal_reserveDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2015, 1, 1), [:federal_reserve], [:observed])[0] || {})[:name]
 
-    assert_equal "Birthday of Martin Luther King, Jr", (Holidays.on(Date.civil(2015, 1, 19), [:federal_reserve], [:observed])[0] || {})[:name]
+    assert_equal "Birthday of Martin Luther King Jr", (Holidays.on(Date.civil(2015, 1, 19), [:federal_reserve], [:observed])[0] || {})[:name]
 
     assert_equal "Washington's Birthday", (Holidays.on(Date.civil(2015, 2, 16), [:federal_reserve], [:observed])[0] || {})[:name]
 
@@ -89,7 +89,7 @@ class Federal_reserveDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2016, 1, 1), [:federal_reserve], [:observed])[0] || {})[:name]
 
-    assert_equal "Birthday of Martin Luther King, Jr", (Holidays.on(Date.civil(2016, 1, 18), [:federal_reserve], [:observed])[0] || {})[:name]
+    assert_equal "Birthday of Martin Luther King Jr", (Holidays.on(Date.civil(2016, 1, 18), [:federal_reserve], [:observed])[0] || {})[:name]
 
     assert_equal "Washington's Birthday", (Holidays.on(Date.civil(2016, 2, 15), [:federal_reserve], [:observed])[0] || {})[:name]
 

--- a/test/defs/test_defs_north_america.rb
+++ b/test/defs/test_defs_north_america.rb
@@ -258,13 +258,13 @@ assert_equal "Easter Sunday", (Holidays.on(Date.civil(2019, 4, 21), [:us], [:inf
 
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2017, 1, 2), [:us], [:observed])[0] || {})[:name]
 
-    assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2019, 1, 21), [:us])[0] || {})[:name]
+    assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2019, 1, 21), [:us])[0] || {})[:name]
 
-    assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2016, 1, 18), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
+    assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2016, 1, 18), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
 
     assert_equal "Martin Luther King's and Robert E. Lee's Birthdays", (Holidays.on(Date.civil(2016, 1, 18), [:us_ms])[0] || {})[:name]
 assert_equal "Martin Luther King's and Robert E. Lee's Birthdays", (Holidays.on(Date.civil(2017, 1, 16), [:us_ms])[0] || {})[:name]

--- a/test/defs/test_defs_nyse.rb
+++ b/test/defs/test_defs_nyse.rb
@@ -14,7 +14,7 @@ assert_equal "New Year's Day", (Holidays.on(Date.civil(2012, 1, 2), [:nyse], [:o
 assert_equal "New Year's Day", (Holidays.on(Date.civil(2011, 1, 1), [:nyse], [:observed])[0] || {})[:name]
 assert_equal "New Year's Day", (Holidays.on(Date.civil(2006, 1, 2), [:nyse], [:observed])[0] || {})[:name]
 
-    assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2008, 1, 21), [:nyse])[0] || {})[:name]
+    assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2008, 1, 21), [:nyse])[0] || {})[:name]
 
     assert_equal "Presidents' Day", (Holidays.on(Date.civil(2008, 2, 18), [:nyse])[0] || {})[:name]
 

--- a/test/defs/test_defs_us.rb
+++ b/test/defs/test_defs_us.rb
@@ -43,13 +43,13 @@ assert_equal "Easter Sunday", (Holidays.on(Date.civil(2019, 4, 21), [:us], [:inf
 
     assert_equal "New Year's Day", (Holidays.on(Date.civil(2017, 1, 2), [:us], [:observed])[0] || {})[:name]
 
-    assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2019, 1, 21), [:us])[0] || {})[:name]
+    assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2019, 1, 21), [:us])[0] || {})[:name]
 
-    assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2016, 1, 18), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
-assert_equal "Martin Luther King, Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
+    assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2016, 1, 18), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2017, 1, 16), [:us])[0] || {})[:name]
+assert_equal "Martin Luther King Jr. Day", (Holidays.on(Date.civil(2018, 1, 15), [:us])[0] || {})[:name]
 
     assert_equal "Martin Luther King's and Robert E. Lee's Birthdays", (Holidays.on(Date.civil(2016, 1, 18), [:us_ms])[0] || {})[:name]
 assert_equal "Martin Luther King's and Robert E. Lee's Birthdays", (Holidays.on(Date.civil(2017, 1, 16), [:us_ms])[0] || {})[:name]


### PR DESCRIPTION
Bumps definitions to pick up https://github.com/TandaHQ/definitions/pull/84 to remove the comma from "Martin Luther King, Jr. Day".