### PR TITLE
Add additional ANZAC Day public holiday for NSW (2026-2027)

### DIFF
--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -40,6 +40,7 @@ module Holidays
             {:mday => 25,  :year_ranges => [{:limited => 2026}],:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "ANZAC Day", :regions => [:au_act]},
             {:mday => 25,  :year_ranges => [{:after => 2027}],:observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "ANZAC Day", :regions => [:au_act]},
             {:mday => 25, :function => "to_monday_if_sunday(date)", :function_arguments => [:date],  :year_ranges => [{:after => 2026}],:name => "ANZAC Day", :regions => [:au_qld]},
+            {:mday => 25, :function => "additional_anzac_on_monday_if_on_weekend(date)", :function_arguments => [:date],  :year_ranges => [{:between => 2026..2027}],:name => "Additional public holiday for ANZAC Day", :regions => [:au_nsw]},
             {:mday => 25, :function => "additional_anzac_on_monday_if_on_weekend(date)", :function_arguments => [:date], :name => "Additional public holiday for ANZAC Day", :regions => [:au_wa]}],
       5 => [{:function => "qld_labour_day_may(year)", :function_arguments => [:year], :name => "Labour Day", :regions => [:au_qld]},
             {:wday => 1, :week => 1, :name => "May Day", :regions => [:au_nt]},

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -305,7 +305,20 @@ class AuDefinitionTests < Test::Unit::TestCase  # :nodoc:
     assert_includes matching_holiday[:regions], :au_wa
 
 
-    assert_nil (Holidays.on(Date.civil(2026, 4, 27), [:au_nsw, :au_vic, :au_tas, :au_sa, :au_nt, :au_qld])[0] || {})[:name]
+    holidays = Holidays.on(Date.civil(2026, 4, 27), [:au_nsw])
+    matching_holiday = holidays.find { |hol| hol[:name] == "Additional public holiday for ANZAC Day" }
+    assert_not_nil matching_holiday
+    assert_equal Date.civil(2026, 4, 27), matching_holiday[:date]
+    assert_includes matching_holiday[:regions], :au_nsw
+
+    holidays = Holidays.on(Date.civil(2027, 4, 26), [:au_nsw])
+    matching_holiday = holidays.find { |hol| hol[:name] == "Additional public holiday for ANZAC Day" }
+    assert_not_nil matching_holiday
+    assert_equal Date.civil(2027, 4, 26), matching_holiday[:date]
+    assert_includes matching_holiday[:regions], :au_nsw
+
+
+    assert_nil (Holidays.on(Date.civil(2026, 4, 27), [:au_vic, :au_tas, :au_sa, :au_nt, :au_qld])[0] || {})[:name]
 
     holidays = Holidays.on(Date.civil(2021, 12, 25), [:au_qld])
     matching_holiday = holidays.find { |hol| hol[:name] == "Christmas Day" }


### PR DESCRIPTION
## Summary
- Updates definitions submodule to include additional ANZAC Day public holiday for NSW
- 2026: ANZAC Day on Saturday Apr 25 → additional holiday Monday Apr 27
- 2027: ANZAC Day on Sunday Apr 25 → additional holiday Monday Apr 26
- Scoped to 2026-2027 only (NSW Government review planned for 2027 on making it permanent)

Source: https://www.nsw.gov.au/ministerial-releases/minns-labor-government-announces-extra-public-holiday-year

Definitions PR: https://github.com/TandaHQ/definitions/pull/88

## Test plan
- [x] `bundle exec rake generate && bundle exec rake test_region au` — 534 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)