### PR TITLE
Add Juneteenth to federal_reserve region

### DIFF
--- a/lib/generated_definitions/federal_reserve.rb
+++ b/lib/generated_definitions/federal_reserve.rb
@@ -16,6 +16,7 @@ module Holidays
             {:wday => 1, :week => 3, :name => "Birthday of Martin Luther King Jr", :regions => [:federal_reserve]}],
       2 => [{:wday => 1, :week => 3, :name => "Washington's Birthday", :regions => [:federal_reserve]}],
       5 => [{:wday => 1, :week => -1, :name => "Memorial Day", :regions => [:federal_reserve]}],
+      6 => [{:mday => 19, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Juneteenth National Independence Day", :regions => [:federal_reserve]}],
       7 => [{:mday => 4, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "Independence Day", :regions => [:federal_reserve]}],
       9 => [{:wday => 1, :week => 1, :name => "Labor Day", :regions => [:federal_reserve]}],
       10 => [{:wday => 1, :week => 2, :name => "Columbus Day", :regions => [:federal_reserve]}],

--- a/test/defs/test_defs_federal_reserve.rb
+++ b/test/defs/test_defs_federal_reserve.rb
@@ -357,5 +357,26 @@ class Federal_reserveDefinitionTests < Test::Unit::TestCase  # :nodoc:
     assert_includes matching_holiday[:regions], :federal_reserve
 
 
+    holidays = Holidays.on(Date.civil(2022, 6, 20), [:federal_reserve], [:observed])
+    matching_holiday = holidays.find { |hol| hol[:name] == "Juneteenth National Independence Day" }
+    assert_not_nil matching_holiday
+    assert_equal Date.civil(2022, 6, 20), matching_holiday[:date]
+    assert_includes matching_holiday[:regions], :federal_reserve
+
+
+    holidays = Holidays.on(Date.civil(2023, 6, 19), [:federal_reserve], [:observed])
+    matching_holiday = holidays.find { |hol| hol[:name] == "Juneteenth National Independence Day" }
+    assert_not_nil matching_holiday
+    assert_equal Date.civil(2023, 6, 19), matching_holiday[:date]
+    assert_includes matching_holiday[:regions], :federal_reserve
+
+
+    holidays = Holidays.on(Date.civil(2024, 6, 19), [:federal_reserve], [:observed])
+    matching_holiday = holidays.find { |hol| hol[:name] == "Juneteenth National Independence Day" }
+    assert_not_nil matching_holiday
+    assert_equal Date.civil(2024, 6, 19), matching_holiday[:date]
+    assert_includes matching_holiday[:regions], :federal_reserve
+
+
   end
 end


### PR DESCRIPTION
## Summary

- Bumps the `definitions` submodule to pick up Juneteenth in `federal_reserve.yaml`
- Regenerates `lib/generated_definitions/federal_reserve.rb` and `test/defs/test_defs_federal_reserve.rb`
- All 159 federal_reserve assertions pass after regeneration

## Why

Juneteenth became a federal holiday in 2021 (Pub. L. 117-17). The Federal Reserve observes it as a closure day, but our `:federal_reserve` region was missing this entry — causing downstream banking-day calculations (e.g. payroll exporters in `payaus`) to incorrectly treat June 19 as an open day.

## Pairs with

- TandaHQ/definitions#91

The submodule pointer in this PR currently points at the head of that PR's branch. After the definitions PR merges, this PR's submodule pointer should be updated to definitions master before merging here.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/defs/test_defs_federal_reserve.rb` — 1 test, 159 assertions, 0 failures
- [ ] Confirm `Holidays.on(Date.new(2025, 6, 19), :federal_reserve, :observed)` returns Juneteenth after this lands