### PR TITLE
HOTFIX | Remove Dia de Pascua from Dominican Republic

### DIFF
--- a/lib/generated_definitions/do.rb
+++ b/lib/generated_definitions/do.rb
@@ -13,7 +13,6 @@ module Holidays
     def self.holidays_by_month
       {
               0 => [{:function => "easter(year)", :function_arguments => [:year], :function_modifier => -2, :name => "Viernes Santo", :regions => [:do]},
-            {:function => "easter(year)", :function_arguments => [:year], :name => "Dia de Pascua", :regions => [:do]},
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 60, :name => "Corpus Christi", :regions => [:do]}],
       1 => [{:mday => 1, :name => "Año Nuevo", :regions => [:do]},
             {:function => "epiphany(year)", :function_arguments => [:year], :name => "Epifanía", :regions => [:do]},

--- a/test/defs/test_defs_do.rb
+++ b/test/defs/test_defs_do.rb
@@ -49,13 +49,6 @@ class DoDefinitionTests < Test::Unit::TestCase  # :nodoc:
     assert_includes matching_holiday[:regions], :do
 
 
-    holidays = Holidays.on(Date.civil(2026, 4, 5), [:do])
-    matching_holiday = holidays.find { |hol| hol[:name] == "Dia de Pascua" }
-    assert_not_nil matching_holiday
-    assert_equal Date.civil(2026, 4, 5), matching_holiday[:date]
-    assert_includes matching_holiday[:regions], :do
-
-
     holidays = Holidays.on(Date.civil(2026, 5, 4), [:do])
     matching_holiday = holidays.find { |hol| hol[:name] == "Dia del Trabajo" }
     assert_not_nil matching_holiday


### PR DESCRIPTION
removing dia de pascua from DR bank holidays